### PR TITLE
Feature/servlet component bindings

### DIFF
--- a/bedrock-core/src/main/groovy/com/citytechinc/aem/bedrock/core/request/impl/DefaultComponentRequest.groovy
+++ b/bedrock-core/src/main/groovy/com/citytechinc/aem/bedrock/core/request/impl/DefaultComponentRequest.groovy
@@ -19,6 +19,7 @@ import static com.adobe.cq.sightly.WCMBindings.CURRENT_STYLE
 import static com.adobe.cq.sightly.WCMBindings.DESIGNER
 import static com.adobe.cq.sightly.WCMBindings.EDIT_CONTEXT
 import static org.apache.sling.api.scripting.SlingBindings.SLING
+import static com.citytechinc.aem.bedrock.core.request.impl.DefaultComponentServletRequest.NAME_COMPONENT_SERVLET_REQUEST
 
 final class DefaultComponentRequest implements ComponentRequest {
 
@@ -39,8 +40,8 @@ final class DefaultComponentRequest implements ComponentRequest {
 
     final SlingScriptHelper sling
 
-    DefaultComponentRequest(Bindings bindings) {
-        componentServletRequest = new DefaultComponentServletRequest(bindings)
+    DefaultComponentRequest(ComponentServletRequest componentServletRequest, Bindings bindings) {
+        this.componentServletRequest = componentServletRequest
 
         component = bindings.get(COMPONENT) as Component
         componentContext = bindings.get(COMPONENT_CONTEXT) as ComponentContext
@@ -49,5 +50,11 @@ final class DefaultComponentRequest implements ComponentRequest {
         currentDesign = bindings.get(CURRENT_DESIGN) as Design
         currentStyle = bindings.get(CURRENT_STYLE) as Style
         sling = bindings.get(SLING) as SlingScriptHelper
+    }
+
+    DefaultComponentRequest(Bindings bindings) {
+
+        this(new DefaultComponentServletRequest(bindings), bindings);
+
     }
 }

--- a/bedrock-core/src/main/java/com/citytechinc/aem/bedrock/core/components/AbstractComponent.java
+++ b/bedrock-core/src/main/java/com/citytechinc/aem/bedrock/core/components/AbstractComponent.java
@@ -41,6 +41,7 @@ public abstract class AbstractComponent implements ComponentNode, Use {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractComponent.class);
 
     private static final String PRECONDITIONS_ERROR_MESSAGE = "component has not been initialized";
+    private static final String SLING_HELPER_PRECONDITIONS_ERROR_MESSAGE = "component has not been initialized or component was initialized from a servlet";
 
     private ComponentRequest componentRequest;
 
@@ -122,7 +123,7 @@ public abstract class AbstractComponent implements ComponentNode, Use {
      * @return the service instance, or null if it is not available
      */
     public final <T> T getService(final Class<T> serviceType) {
-        return checkNotNull(sling, PRECONDITIONS_ERROR_MESSAGE).getService(serviceType);
+        return checkNotNull(sling, SLING_HELPER_PRECONDITIONS_ERROR_MESSAGE).getService(serviceType);
     }
 
     /**
@@ -135,7 +136,7 @@ public abstract class AbstractComponent implements ComponentNode, Use {
      */
     @SuppressWarnings("unchecked")
     public final <T> List<T> getServices(final Class<T> serviceType, final String filter) {
-        return (List<T>) ImmutableList.of(checkNotNull(sling, PRECONDITIONS_ERROR_MESSAGE).getServices(serviceType,
+        return (List<T>) ImmutableList.of(checkNotNull(sling, SLING_HELPER_PRECONDITIONS_ERROR_MESSAGE).getServices(serviceType,
             filter));
     }
 

--- a/bedrock-core/src/main/java/com/citytechinc/aem/bedrock/core/servlets/AbstractComponentServlet.java
+++ b/bedrock-core/src/main/java/com/citytechinc/aem/bedrock/core/servlets/AbstractComponentServlet.java
@@ -18,6 +18,8 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.scripting.core.ScriptHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +44,7 @@ import static com.day.cq.wcm.core.impl.WCMBindingsValuesProvider.NAME_RESOURCE_P
 import static com.day.cq.wcm.core.impl.WCMBindingsValuesProvider.NAME_PAGE_PROPERTIES;
 import static com.day.cq.wcm.core.impl.WCMBindingsValuesProvider.NAME_RESOURCE_DESIGN;
 import static com.day.cq.wcm.core.impl.WCMBindingsValuesProvider.NAME_XSSAPI;
+import static org.apache.sling.api.scripting.SlingBindings.SLING;
 
 /**
  * Proxy servlet that wraps the Sling request in a "component" request for access to convenience accessor methods.
@@ -51,6 +54,25 @@ public abstract class AbstractComponentServlet extends AbstractJsonResponseServl
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractComponentServlet.class);
+
+    private SlingScriptHelper slingScriptHelper;
+
+    protected final void activate(org.osgi.service.component.ComponentContext context) {
+        slingScriptHelper = new ScriptHelper(context.getBundleContext(), null);
+
+        processActivate(context);
+    }
+
+    /**
+     * To be implemented by extending Servlets in cases where Servlets need to provide some manner of
+     * activation logic.  Extending servlets should add activation logic via this method and should <strong>never</strong>
+     * annotate a separate method as the activator.
+     *
+     * @param context OSGI Component Context
+     */
+    protected void processActivate(org.osgi.service.component.ComponentContext context) {
+
+    }
 
     @Override
     protected final void doDelete(final SlingHttpServletRequest request, final SlingHttpServletResponse response)
@@ -158,6 +180,7 @@ public abstract class AbstractComponentServlet extends AbstractJsonResponseServl
         componentBindings.put(NAME_DESIGNER, designer);
         componentBindings.put(NAME_CURRENT_DESIGN, currentDesign);
         componentBindings.put(NAME_CURRENT_STYLE, currentStyle);
+        componentBindings.put(SLING, slingScriptHelper);
 
         ComponentRequest componentRequest = new DefaultComponentRequest(request, componentBindings);
 

--- a/bedrock-core/src/main/java/com/citytechinc/aem/bedrock/core/servlets/AbstractComponentServlet.java
+++ b/bedrock-core/src/main/java/com/citytechinc/aem/bedrock/core/servlets/AbstractComponentServlet.java
@@ -146,10 +146,10 @@ public abstract class AbstractComponentServlet extends AbstractJsonResponseServl
 
         Designer designer = request.getResourceResolver().adaptTo(Designer.class);
         Page currentPage = componentContext == null ? null : componentContext.getPage();
-        Design currentDesign = designer.getDesign(currentPage);
+        Design currentDesign = designer == null ? null : designer.getDesign(currentPage);
         Style currentStyle = componentContext == null || currentDesign == null ? null : currentDesign.getStyle(componentContext.getCell());
 
-        ValueMap properties = request.getResource().adaptTo(ValueMap.class);
+        ValueMap properties = request.getResource() == null ? null : request.getResource().adaptTo(ValueMap.class);
 
         componentBindings.put(NAME_PROPERTIES, properties);
         componentBindings.put(NAME_COMPONENT_CONTEXT, componentContext);

--- a/bedrock-core/src/test/groovy/com/citytechinc/aem/bedrock/core/servlets/AbstractComponentServletSpec.groovy
+++ b/bedrock-core/src/test/groovy/com/citytechinc/aem/bedrock/core/servlets/AbstractComponentServletSpec.groovy
@@ -1,7 +1,11 @@
 package com.citytechinc.aem.bedrock.core.servlets
 
+import com.citytechinc.aem.bedrock.api.request.ComponentRequest
 import com.citytechinc.aem.bedrock.api.request.ComponentServletRequest
+import com.citytechinc.aem.bedrock.core.components.AbstractComponent
+import com.citytechinc.aem.bedrock.core.request.impl.DefaultComponentServletRequest
 import com.citytechinc.aem.bedrock.core.specs.BedrockSpec
+import com.google.common.base.Optional
 import groovy.json.JsonBuilder
 
 import javax.servlet.ServletException
@@ -22,11 +26,26 @@ class AbstractComponentServletSpec extends BedrockSpec {
         setup:
         def request = requestBuilder.build()
         def response = responseBuilder.build()
-                                         instantiate and initialize
+
         when:
         new ComponentServlet().doGet(request, response)
 
         then:
         response.contentAsString == new JsonBuilder(MAP).toString()
+    }
+
+    def "get component"() {
+        setup:
+        def request = requestBuilder.build()
+        def response = responseBuilder.build()
+
+        when:
+        def componentRequest = new DefaultComponentServletRequest(request, response)
+        def componentServlet = new ComponentServlet()
+        def Optional<SimpleComponent> componentInstance = componentServlet.getComponent(componentRequest, SimpleComponent)
+
+        then:
+        componentInstance.isPresent()
+        componentInstance.get().initialized
     }
 }

--- a/bedrock-core/src/test/groovy/com/citytechinc/aem/bedrock/core/servlets/AbstractComponentServletSpec.groovy
+++ b/bedrock-core/src/test/groovy/com/citytechinc/aem/bedrock/core/servlets/AbstractComponentServletSpec.groovy
@@ -22,7 +22,7 @@ class AbstractComponentServletSpec extends BedrockSpec {
         setup:
         def request = requestBuilder.build()
         def response = responseBuilder.build()
-
+                                         instantiate and initialize
         when:
         new ComponentServlet().doGet(request, response)
 

--- a/bedrock-core/src/test/groovy/com/citytechinc/aem/bedrock/core/servlets/SimpleComponent.groovy
+++ b/bedrock-core/src/test/groovy/com/citytechinc/aem/bedrock/core/servlets/SimpleComponent.groovy
@@ -1,0 +1,15 @@
+package com.citytechinc.aem.bedrock.core.servlets
+
+import com.citytechinc.aem.bedrock.api.request.ComponentRequest
+import com.citytechinc.aem.bedrock.core.components.AbstractComponent
+
+class SimpleComponent extends AbstractComponent {
+
+    boolean initialized
+
+    @Override
+    public void init(final ComponentRequest request) {
+        initialized = true
+    }
+
+}


### PR DESCRIPTION
Added a getComponent method to the AbstractComponentServlet.  This exposes the ability to retrieve an AbstractComponent instance representing the Resource requested.  Under the hood, the method repeats some of the logic found in the WCMBindingsValuesProvider, reconstituting the majority of the objects the AbstractComponent requires to do its magic.  