### PR TITLE
Added test property to bedrock:disableAuthor tag.

### DIFF
--- a/bedrock-core/src/main/groovy/com/citytechinc/aem/bedrock/core/tags/DisableAuthorTag.groovy
+++ b/bedrock-core/src/main/groovy/com/citytechinc/aem/bedrock/core/tags/DisableAuthorTag.groovy
@@ -16,31 +16,44 @@ final class DisableAuthorTag extends TagSupport {
 
     private static final def ATTR_PREVIOUS_WCMMODE = "previous-wcm-mode-"
 
+    /**
+     * Disables author if true, otherwise this tag does nothing. Defaults to true.
+     */
+    String test
+
     @Override
     int doStartTag() {
-        def slingRequest = pageContext.getAttribute(DEFAULT_REQUEST_NAME) as SlingHttpServletRequest
+        boolean test = !this.test ? true : Boolean.valueOf(this.test)
 
-        def path = slingRequest.resource.path
+        if (test) {
+            def slingRequest = pageContext.getAttribute(DEFAULT_REQUEST_NAME) as SlingHttpServletRequest
 
-        LOG.debug "disabling authoring for path = {}", path
+            def path = slingRequest.resource.path
 
-        slingRequest.setAttribute(ATTR_PREVIOUS_WCMMODE + path, WCMMode.fromRequest(slingRequest))
+            LOG.debug "disabling authoring for path = {}", path
 
-        WCMMode.DISABLED.toRequest(slingRequest)
+            slingRequest.setAttribute(ATTR_PREVIOUS_WCMMODE + path, WCMMode.fromRequest(slingRequest))
+
+            WCMMode.DISABLED.toRequest(slingRequest)
+        }
 
         EVAL_BODY_INCLUDE
     }
 
     @Override
     int doEndTag() {
-        def slingRequest = pageContext.getAttribute(DEFAULT_REQUEST_NAME) as SlingHttpServletRequest
+        boolean test = !this.test ? true : Boolean.valueOf(this.test)
+        
+        if (test) {
+            def slingRequest = pageContext.getAttribute(DEFAULT_REQUEST_NAME) as SlingHttpServletRequest
 
-        def path = slingRequest.resource.path
-        def mode = slingRequest.getAttribute(ATTR_PREVIOUS_WCMMODE + path) as WCMMode
+            def path = slingRequest.resource.path
+            def mode = slingRequest.getAttribute(ATTR_PREVIOUS_WCMMODE + path) as WCMMode
 
-        LOG.debug "restoring mode = {} for path = {}", mode.name(), path
+            LOG.debug "restoring mode = {} for path = {}", mode.name(), path
 
-        mode.toRequest(slingRequest)
+            mode.toRequest(slingRequest)
+        }
 
         EVAL_PAGE
     }

--- a/bedrock-core/src/main/resources/META-INF/bedrock.tld
+++ b/bedrock-core/src/main/resources/META-INF/bedrock.tld
@@ -15,6 +15,11 @@
     <tag>
         <name>disableAuthor</name>
         <tag-class>com.citytechinc.aem.bedrock.core.tags.DisableAuthorTag</tag-class>
+        <attribute>
+            <name>test</name>
+            <required>false</required>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
     </tag>
     <tag>
         <name>includeDeferredClientLib</name>

--- a/src/site/markdown/tag-library.md
+++ b/src/site/markdown/tag-library.md
@@ -27,6 +27,10 @@ isDebug | If true, the resource path/type and script details will be included in
 
 Force "disabled" WCM mode in the tag body.  Useful for removing authoring capabilities in nested components.
 
+Attribute | Required | Description
+:---------|:---------|:-----------
+test | false | Disables author if true, otherwise this tag does nothing.  Defaults to `true`.
+
     <bedrock:disableAuthor>
         ...
     </bedrock:disableAuthor>


### PR DESCRIPTION
On the projects I've worked on, I've found that, when I want to disable authoring capabilities for a component, I've almost always wanted to do so conditionally (based on page depth, user state, etc). Therefore, I thought it would be useful to add a simple conditional capability to Bedrock's bedrock:disableAuthor tag.

The property name, test, I chose based on the JSTL Core c:if tag. I based the implementation and style choices on the escapeXml property for the bedrock:property tag. Specifically the choice to keep the value as a String rather than a boolean (a choice which I don't fully understand, but I wanted to stay consistent).

I tested this on a Geometrixx Media page for the following values of test:
* Default (property not present)
* true
* false
* ${isAuthor}
* ${not isAuthor}

In addition to the code change, I've updated the tag-library.md file for documentation. Unfortunately, I wasn't able to get the site to build with maven, but I did check the formatting via GitHub's built-in markdown viewer.

Please let me know what you think! If this doesn't fit in the project, or there is already an easy way to do this without this addition, let me know!

Thank you!